### PR TITLE
feat: pass in users public wallet address

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ function App() {
       name: 'Portal',
       imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/5d55353a3f95997ce7b33bc08c6832ed',
       quantity: 1,
+      walletAddress: publicAddress,
     })
   }
 


### PR DESCRIPTION
- pass in the wallet address of the current user

```
    await magic.nft.checkout({
      contractId: '1e719eaa-990e-41cf-b2e0-a4eb3d5d1312',
      tokenId: '2',
      name: 'Portal',
      imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/5d55353a3f95997ce7b33bc08c6832ed',
      quantity: 1,
      walletAddress: publicAddress,
    })
```